### PR TITLE
Add search by school name

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,6 +98,26 @@ ul.school-details {
 	background-color: rgba(255, 255, 255, 0.9);
 }
 
-.block-intro .btn {
-	margin-top: 0.5em; /* vertically separate buttons on narrow screens */
+.block-intro .btn.school-level {
+	margin-bottom: 0.5em; /* vertically separate buttons on narrow screens */
+}
+
+.jumbotron #or {
+	text-transform: uppercase;
+	font-weight: 800;
+	margin-top: 0;
+	font-size: 21px;
+}
+.jumbotron p {
+	font-size: 18px;
+	margin-bottom: 1em;
+}
+.jumbotron p.lead {
+	margin-bottom: 1em;
+	margin-top: 1em;
+}
+.jumbotron .disclaimer {
+	margin-top: 1em;
+	margin-bottom: 0em;
+	color: rgb(153, 153, 153);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -121,3 +121,7 @@ ul.school-details {
 	margin-bottom: 0em;
 	color: rgb(153, 153, 153);
 }
+.school-name-search {
+	margin-right: 2em;
+	margin-left: 2em;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,11 @@ body { background-color: #39acc9; color: #3e3e3e; }
 
 .container .jumbotron { background-color: #f7f6f6; border-radius: 0px;}
 .btn-success { background-color: #d72d6c; border: none; border-radius: 0px;}
-.footer p {color: #f7f6f6; }
+#button-search-name, #button-search-address {
+	background-color: #d72d6c;
+	color: white;
+}
+.footer p {color: #f7f6f6;}
 
 .cartodb-map { width: 100%; height:100%; height: 500px; background: black; }
 

--- a/index.html
+++ b/index.html
@@ -86,16 +86,33 @@
     </div> <!-- /container -->
 
     <!-- Modal -->
-    <div class="modal fade" id="noResultsModal" tabindex="-1" role="dialog" aria-labelledby="noResultsModalLabel" aria-hidden="true">
+    <div class="modal fade" id="noResultsForAddressModal" tabindex="-1" role="dialog" aria-labelledby="noResultsForAddressModalLabel" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="noResultsModalLabel">Nothing found. &nbsp; ๏̯̃๏</h4>
+            <h4 class="modal-title" id="noResultsForAddressModalLabel">Nothing found. &nbsp; ๏̯̃๏</h4>
           </div>
           <div class="modal-body">
             <p>Sorry, I don't know of any schools there. Feel free to try another search though!</p>
             <p class="more-info">You might be interested in <a href="http://www.schools.nsw.edu.au/rde/ruraledu/index.php" target="_blank">rural and distance education</a> options.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal fade" id="noResultsForNameModal" tabindex="-1" role="dialog" aria-labelledby="noResultsForNameModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="noResultsForNameModalLabel">Nothing found. &nbsp; ๏̯̃๏</h4>
+          </div>
+          <div class="modal-body">
+            <p>Sorry, I don't know of any schools like that. Feel free to try another search though!</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <div class="row school-name-search">
           <div class="col-lg-12">
             <div class="input-group input-group-lg">
-              <input type="text" class="form-control" placeholder="Search for...">
+              <input type="text" class="form-control" placeholder="A school named...">
               <span class="input-group-btn">
                 <button id="button-search-name" class="btn btn-default" type="button">Search</button>
               </span>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <div class="input-group input-group-lg">
               <input type="text" class="form-control" placeholder="Search for...">
               <span class="input-group-btn">
-                <button id="button-search-names" class="btn btn-default" type="button">Search</button>
+                <button id="button-search-name" class="btn btn-default" type="button">Search</button>
               </span>
             </div><!-- /input-group -->
           </div>
@@ -72,7 +72,7 @@
         <h1>I live at:</h1>
         <p class="lead">Provide an address so we can look up nearby schools:</p>
         <p><input id="address" type="text" class="form-control" placeholder="Home address" data-google-places=true/></p>
-        <a class="btn btn-lg btn-success search" href="#" role="button">Search</a>
+        <a id="button-search-address" class="btn btn-lg btn-success search" href="#" role="button">Search</a>
       </div>
 
       <!-- RESULT -->

--- a/index.html
+++ b/index.html
@@ -173,7 +173,9 @@
           <!-- <li><span class="field-label">Distance: </span><span class="school-code">{{distanceEd}}</span></li> -->
 
         </ul>
-        <p class='school-info-intro'>This school serves your location (<span class="address">{{homeAddress}}</span>).</p>
+        {{#if homeAddress}}
+          <p class='school-info-intro'>This school serves your location (<span class="address">{{homeAddress}}</span>).</p>
+        {{/if}}
       </div>
 
     </script>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,9 @@
 
         <ul class="school-details">
 
-          {{#if distance}}<li class="school-distance"><span class="field-label">Distance: </span><span class="field-data">{{distance}} as the crow flies</span><span class="route-distance"></span></li>{{/if}}
+          {{#if distance}}
+            <li class="school-distance"><span class="field-label">Distance: </span><span class="field-data">{{distance}} as the crow flies</span><span class="route-distance"></span></li>
+          {{/if}}
           <li class="school-address"><span class="field-label">Address: </span><span class="field-data">{{address}}, {{suburb}} NSW {{postcode}}</span>
           <li class="school-phone"><span class="field-label">Phone: </span><span class="field-data">{{phone}}</span></li>
           <li class="school-email"><span class="field-label">Email: </span><span class="field-data"><a href="mailto:{{email}}">{{email}}</a></span></li>

--- a/index.html
+++ b/index.html
@@ -121,6 +121,24 @@
       </div>
     </div>
 
+
+    <div class="modal fade" id="tooManyResultsModal" tabindex="-1" role="dialog" aria-labelledby="tooManyResultsModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="tooManyResultsModalLabel">Yikes! There are too many results. &nbsp; ¯(°_o)/¯</h4> <!-- other emoji: ⊙﹏⊙ or ⊙▂⊙ -->
+          </div>
+          <div class="modal-body">
+            <p>I found <span class="results-count">way too many</span> results and can't display them all. Feel free to try another search though!</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -54,18 +54,16 @@
         </p>
         <p id="or">or</p>
         <p>Lookup a school by name:</p>
-        <form>
-          <div class="row">
-            <div class="col-lg-12">
-              <div class="input-group input-group-lg school-name-search">
-                <input type="text" class="form-control" placeholder="Search for...">
-                <span class="input-group-btn">
-                  <button id="button-search-names" class="btn btn-default" type="button">Search</button>
-                </span>
-              </div><!-- /input-group -->
-            </div>
-          </div><!-- /.row -->
-        </form>
+        <div class="row school-name-search">
+          <div class="col-lg-12">
+            <div class="input-group input-group-lg">
+              <input type="text" class="form-control" placeholder="Search for...">
+              <span class="input-group-btn">
+                <button id="button-search-names" class="btn btn-default" type="button">Search</button>
+              </span>
+            </div><!-- /input-group -->
+          </div>
+        </div><!-- /.row -->
 
         <p class="disclaimer">Information subject to change; by using this, you agree to not sue us.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -47,11 +47,27 @@
 
       <div class="jumbotron block-intro">
         <h1>I'm looking for:</h1>
-        <p class="lead">Select your school type below. Information subject to change; by using this, you agree to not sue us.</p>
+        <p class="lead">Select your school type below.</p>
         <p>
-          <a class="btn btn-lg btn-success primary" href="#" role="button">Primary school</a>
-          <a class="btn btn-lg btn-success secondary" href="#" role="button">Secondary school</a>
+          <a class="btn btn-lg btn-success primary school-level" href="#" role="button">Primary school</a>
+          <a class="btn btn-lg btn-success secondary school-level" href="#" role="button">Secondary school</a>
         </p>
+        <p id="or">or</p>
+        <p>Lookup a school by name:</p>
+        <form>
+          <div class="row">
+            <div class="col-lg-12">
+              <div class="input-group input-group-lg school-name-search">
+                <input type="text" class="form-control" placeholder="Search for...">
+                <span class="input-group-btn">
+                  <button id="button-search-names" class="btn btn-default" type="button">Search</button>
+                </span>
+              </div><!-- /input-group -->
+            </div>
+          </div><!-- /.row -->
+        </form>
+
+        <p class="disclaimer">Information subject to change; by using this, you agree to not sue us.</p>
       </div>
 
       <div class="jumbotron block-address">

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
 
         <ul class="school-details">
 
-          <li class="school-distance"><span class="field-label">Distance: </span><span class="field-data">{{distance}} as the crow flies</span><span class="route-distance"></span></li>
+          {{#if distance}}<li class="school-distance"><span class="field-label">Distance: </span><span class="field-data">{{distance}} as the crow flies</span><span class="route-distance"></span></li>{{/if}}
           <li class="school-address"><span class="field-label">Address: </span><span class="field-data">{{address}}, {{suburb}} NSW {{postcode}}</span>
           <li class="school-phone"><span class="field-label">Phone: </span><span class="field-data">{{phone}}</span></li>
           <li class="school-email"><span class="field-label">Email: </span><span class="field-data"><a href="mailto:{{email}}">{{email}}</a></span></li>

--- a/js/app.js
+++ b/js/app.js
@@ -7,10 +7,10 @@ app.sql = new cartodb.SQL({ user: app.db.user });
 $(document).ready(function () {
 
   // Make school level buttons equal width
-  var maxWidth = Math.max.apply(null, $('.block-intro .btn').map(function () {
+  var maxWidth = Math.max.apply(null, $('.block-intro .btn.school-level').map(function () {
     return $(this).outerWidth(true);
   }).get());
-  $('.block-intro .btn').width(maxWidth);
+  $('.block-intro .btn.school-level').width(maxWidth);
 
   var clickSchoolType = function (e) {
     e.preventDefault();

--- a/js/app.js
+++ b/js/app.js
@@ -99,15 +99,12 @@ app.getResults = function () {
 
   var scrollToMap = function ($el) {
     // scroll to first result
-    if (!alreadyScrolled) {
-      $('html, body').animate({
-        scrollTop: $el.offset().top,
-      }, 500, function () {
-        resetSearchBtn();
-      });
-    }
+    $('html, body').animate({
+      scrollTop: $el.offset().top,
+    }, 500, function () {
+      resetSearchBtn();
+    });
   };
-
 
   var mapRow = function (row, i) {
     var context, source, template, html, mapID, schoolsSQL, catchmentsSQL;

--- a/js/app.js
+++ b/js/app.js
@@ -56,7 +56,7 @@ app = app || {};
       setSearchBtnToWorking();
 
       // Geocode address then show results
-      app.geocodeAddress(app.getResults);
+      app.geocodeAddress(app.findByLocation);
 
     });
 
@@ -164,7 +164,7 @@ app = app || {};
   };
 
   // update results for a specific lat/lng
-  app.getResults = function () {
+  app.findByLocation = function () {
 
     // clean up any previous result
     $('#results-container .result').remove();

--- a/js/app.js
+++ b/js/app.js
@@ -24,6 +24,13 @@ $(document).ready(function () {
   $(".btn.primary").click({level: 'primary'}, clickSchoolType);
   $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
 
+  $("#button-search-names").click(function () {
+    var name = $('.school-name-search input').val();
+    console.log("looking for...");
+    console.log(name);
+    app.findByName(name);
+  });
+
   $(".btn.search").click(function (e) {
     e.preventDefault();
 
@@ -49,6 +56,27 @@ $(document).ready(function () {
   });
 });
 
+app.findByName = function (name) {
+
+  // Find schools by name
+  var query = "SELECT b.the_geom AS catchment_geom, s.* " +
+              "FROM " + app.db.points + " AS s " +
+              "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
+              "ON s.school_code = b.school_code " +
+              "WHERE s.school_name ILIKE '%" + name + "%'";
+  app.sql.execute(query)
+    .done(function (data) {
+      if (data.rows.length < 1) {
+        console.log("No luck; go fish!");
+      } else {
+        // data.rows.forEach(mapRow);
+        data.rows.forEach(function (data) {
+          console.log("found school");
+          console.log(data);
+        });
+      }
+    });
+};
 
 // update results for a specific lat/lng
 app.getResults = function () {

--- a/js/app.js
+++ b/js/app.js
@@ -8,93 +8,6 @@ app = app || {};
 
   var searchMethod; // 'address' or 'name';
 
-  $(document).ready(function () {
-
-    // Make school level buttons equal width
-    var maxWidth = Math.max.apply(null, $('.block-intro .btn.school-level').map(function () {
-      return $(this).outerWidth(true);
-    }).get());
-    $('.block-intro .btn.school-level').width(maxWidth);
-
-    var clickSchoolType = function (e) {
-      e.preventDefault();
-      app.level = e.data.level;
-      // jump to the address search
-      $('html, body').animate({
-        scrollTop: $(".block-address").offset().top - 100 //HACK to center in window.
-      }, 500);
-    };
-
-    $(".btn.primary").click({level: 'primary'}, clickSchoolType);
-    $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
-
-    $("#button-search-name").click(function () {
-
-      searchMethod = 'name';
-
-      // Use Search button as status
-      setSearchBtnToWorking();
-
-      var name = $('.school-name-search input').val();
-      console.log("looking for...");
-      console.log(name);
-
-      if (!name) {
-        console.log('nothing entered to search for, not trying!');
-        setTimeout(function () {resetSearchBtn();}, 200);
-      } else {
-        app.findByName(name);
-      }
-    });
-
-    $("#button-search-address").click(function (e) {
-      e.preventDefault();
-
-      searchMethod = 'address';
-
-      // Use Search button as status
-      setSearchBtnToWorking();
-
-      // Geocode address then show results
-      app.geocodeAddress(app.findByLocation);
-
-    });
-
-    $("#address").keyup(function (event) {
-      if (event.keyCode === 13) {
-        $(".btn.search").click();
-      }
-    });
-  });
-
-  app.findByName = function (name) {
-
-    // Find schools by name
-    var query = "SELECT b.the_geom AS catchment_geom, s.* " +
-                "FROM " + app.db.points + " AS s " +
-                "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
-                "ON s.school_code = b.school_code " +
-                "WHERE s.school_name ILIKE '%" + name + "%'";
-    app.sql.execute(query)
-      .done(function (data) {
-        resetSearchBtn();
-        if (data.rows.length < 1) {
-          console.log("No luck; go fish!");
-          $('#noResultsForNameModal').modal();
-        } else {
-          // data.rows.forEach(mapRow);
-          // data.rows.forEach(function (data) {
-          //   console.log("found school");
-          //   console.log(data);
-          // });
-        }
-      }).error(function(errors) {
-        resetSearchBtn();
-        // errors contains a list of errors
-        console.log("errors:" + errors);
-      });
-  };
-
   var getSearchBtn = function () {
     var $btn;
     if (searchMethod === 'name') {
@@ -164,6 +77,34 @@ app = app || {};
     if (i === 0) { scrollToMap($result); }
   };
 
+  app.findByName = function (name) {
+
+    // Find schools by name
+    var query = "SELECT b.the_geom AS catchment_geom, s.* " +
+                "FROM " + app.db.points + " AS s " +
+                "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
+                "ON s.school_code = b.school_code " +
+                "WHERE s.school_name ILIKE '%" + name + "%'";
+    app.sql.execute(query)
+      .done(function (data) {
+        resetSearchBtn();
+        if (data.rows.length < 1) {
+          console.log("No luck; go fish!");
+          $('#noResultsForNameModal').modal();
+        } else {
+          // data.rows.forEach(mapRow);
+          // data.rows.forEach(function (data) {
+          //   console.log("found school");
+          //   console.log(data);
+          // });
+        }
+      }).error(function(errors) {
+        resetSearchBtn();
+        // errors contains a list of errors
+        console.log("errors:" + errors);
+      });
+  };
+
   // update results for a specific lat/lng
   app.findByLocation = function () {
 
@@ -212,5 +153,64 @@ app = app || {};
     app.maps.push(m);
     return m;
   };
+
+  $(document).ready(function () {
+
+    // Make school level buttons equal width
+    var maxWidth = Math.max.apply(null, $('.block-intro .btn.school-level').map(function () {
+      return $(this).outerWidth(true);
+    }).get());
+    $('.block-intro .btn.school-level').width(maxWidth);
+
+    var clickSchoolType = function (e) {
+      e.preventDefault();
+      app.level = e.data.level;
+      // jump to the address search
+      $('html, body').animate({
+        scrollTop: $(".block-address").offset().top - 100 //HACK to center in window.
+      }, 500);
+    };
+
+    $(".btn.primary").click({level: 'primary'}, clickSchoolType);
+    $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
+
+    $("#button-search-name").click(function () {
+
+      searchMethod = 'name';
+
+      // Use Search button as status
+      setSearchBtnToWorking();
+
+      var name = $('.school-name-search input').val();
+      console.log("looking for...");
+      console.log(name);
+
+      if (!name) {
+        console.log('nothing entered to search for, not trying!');
+        setTimeout(function () {resetSearchBtn();}, 200);
+      } else {
+        app.findByName(name);
+      }
+    });
+
+    $("#button-search-address").click(function (e) {
+      e.preventDefault();
+
+      searchMethod = 'address';
+
+      // Use Search button as status
+      setSearchBtnToWorking();
+
+      // Geocode address then show results
+      app.geocodeAddress(app.findByLocation);
+
+    });
+
+    $("#address").keyup(function (event) {
+      if (event.keyCode === 13) {
+        $(".btn.search").click();
+      }
+    });
+  });
 
 }());

--- a/js/app.js
+++ b/js/app.js
@@ -92,6 +92,14 @@ app = app || {};
 
   app.findByName = function (name) {
 
+    // Prevent people from searching for things which will result in too many responses
+    if ($.inArray(name, ['public', 'school', 'high', 'central', 'infant', ' ']) !== -1) {
+      $('#tooManyResultsModal .results-count').text('way too many');
+      $('#tooManyResultsModal').modal();
+      resetSearchBtn();
+      return;
+    }
+
     // Find schools by name
     var query = "SELECT b.the_geom AS catchment_geom, b.shape_area, s.* " +
                 "FROM " + app.db.points + " AS s " +
@@ -104,6 +112,9 @@ app = app || {};
         if (data.rows.length < 1) {
           console.log("No luck; go fish!");
           $('#noResultsForNameModal').modal();
+        } else if (data.rows.length > 10) {
+          $('#tooManyResultsModal .results-count').text(data.rows.length);
+          $('#tooManyResultsModal').modal();
         } else {
           data.rows.forEach(mapRow);
         }

--- a/js/app.js
+++ b/js/app.js
@@ -26,14 +26,14 @@ app = app || {};
     $(".btn.primary").click({level: 'primary'}, clickSchoolType);
     $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
 
-    $("#button-search-names").click(function () {
+    $("#button-search-name").click(function () {
       var name = $('.school-name-search input').val();
       console.log("looking for...");
       console.log(name);
       app.findByName(name);
     });
 
-    $(".btn.search").click(function (e) {
+    $("#button-search-address").click(function (e) {
       e.preventDefault();
 
       var $btn = $(this);

--- a/js/app.js
+++ b/js/app.js
@@ -38,7 +38,13 @@ app = app || {};
       var name = $('.school-name-search input').val();
       console.log("looking for...");
       console.log(name);
-      app.findByName(name);
+
+      if (!name) {
+        console.log('nothing entered to search for, not trying!');
+        setTimeout(function () {resetSearchBtn();}, 200);
+      } else {
+        app.findByName(name);
+      }
     });
 
     $("#button-search-address").click(function (e) {
@@ -71,16 +77,20 @@ app = app || {};
                 "WHERE s.school_name ILIKE '%" + name + "%'";
     app.sql.execute(query)
       .done(function (data) {
+        resetSearchBtn();
         if (data.rows.length < 1) {
           console.log("No luck; go fish!");
         } else {
-          resetSearchBtn();
           // data.rows.forEach(mapRow);
           // data.rows.forEach(function (data) {
           //   console.log("found school");
           //   console.log(data);
           // });
         }
+      }).error(function(errors) {
+        resetSearchBtn();
+        // errors contains a list of errors
+        console.log("errors:" + errors);
       });
   };
 

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,8 @@ app = app || {};
   app.maps = [];
   app.sql = new cartodb.SQL({ user: app.db.user });
 
+  var searchMethod; // 'address' or 'name';
+
   $(document).ready(function () {
 
     // Make school level buttons equal width
@@ -27,6 +29,12 @@ app = app || {};
     $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
 
     $("#button-search-name").click(function () {
+
+      searchMethod = 'name';
+
+      // Use Search button as status
+      setSearchBtnToWorking();
+
       var name = $('.school-name-search input').val();
       console.log("looking for...");
       console.log(name);
@@ -36,14 +44,10 @@ app = app || {};
     $("#button-search-address").click(function (e) {
       e.preventDefault();
 
-      var $btn = $(this);
-      $btn.data('default-text', $btn.html());
-      $btn.data('default-bgcolor', $btn.css('background-color'));
+      searchMethod = 'address';
 
       // Use Search button as status
-      $btn.html('Working&hellip;');
-      $btn.css('background-color', 'gray');
-
+      setSearchBtnToWorking();
 
       // Geocode address then show results
       app.geocodeAddress(app.getResults);
@@ -70,6 +74,7 @@ app = app || {};
         if (data.rows.length < 1) {
           console.log("No luck; go fish!");
         } else {
+          resetSearchBtn();
           // data.rows.forEach(mapRow);
           // data.rows.forEach(function (data) {
           //   console.log("found school");
@@ -79,10 +84,29 @@ app = app || {};
       });
   };
 
+  var getSearchBtn = function () {
+    var $btn;
+    if (searchMethod === 'name') {
+      $btn = $('#button-search-name');
+    } else if (searchMethod === 'address') {
+      $btn = $('#button-search-address');
+    }
+    return $btn;
+  };
+
+  // Reset Search button to it's default state
   var resetSearchBtn = function () {
-    // Reset Search button
-    var $btn = $('.btn.search');
+    var $btn = getSearchBtn();
     $btn.text($btn.data('default-text')).css('background-color', $btn.data('default-bgcolor'));
+  };
+
+  // Put Search button in 'Working' (show status) state
+  var setSearchBtnToWorking = function () {
+    var $btn = getSearchBtn();
+    $btn.data('default-text', $btn.html());
+    $btn.data('default-bgcolor', $btn.css('background-color'));
+    $btn.html('Working&hellip;');
+    $btn.css('background-color', 'gray');
   };
 
   var scrollToMap = function ($result) {

--- a/js/app.js
+++ b/js/app.js
@@ -85,10 +85,10 @@ app = app || {};
     $btn.text($btn.data('default-text')).css('background-color', $btn.data('default-bgcolor'));
   };
 
-  var scrollToMap = function ($el) {
+  var scrollToMap = function ($result) {
     // scroll to first result
     $('html, body').animate({
-      scrollTop: $el.offset().top,
+      scrollTop: $result.offset().top,
     }, 500, function () {
       resetSearchBtn();
     });

--- a/js/app.js
+++ b/js/app.js
@@ -98,7 +98,7 @@ app = app || {};
           //   console.log(data);
           // });
         }
-      }).error(function(errors) {
+      }).error(function (errors) {
         resetSearchBtn();
         // errors contains a list of errors
         console.log("errors:" + errors);
@@ -187,7 +187,7 @@ app = app || {};
 
       if (!name) {
         console.log('nothing entered to search for, not trying!');
-        setTimeout(function () {resetSearchBtn();}, 200);
+        setTimeout(function () {resetSearchBtn(); }, 200);
       } else {
         app.findByName(name);
       }

--- a/js/app.js
+++ b/js/app.js
@@ -1,180 +1,182 @@
 var app, Map, L, cartodb, google, Handlebars;
 app = app || {};
 
-app.maps = [];
-app.sql = new cartodb.SQL({ user: app.db.user });
+(function () {
 
-$(document).ready(function () {
-
-  // Make school level buttons equal width
-  var maxWidth = Math.max.apply(null, $('.block-intro .btn.school-level').map(function () {
-    return $(this).outerWidth(true);
-  }).get());
-  $('.block-intro .btn.school-level').width(maxWidth);
-
-  var clickSchoolType = function (e) {
-    e.preventDefault();
-    app.level = e.data.level;
-    // jump to the address search
-    $('html, body').animate({
-      scrollTop: $(".block-address").offset().top - 100 //HACK to center in window.
-    }, 500);
-  };
-
-  $(".btn.primary").click({level: 'primary'}, clickSchoolType);
-  $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
-
-  $("#button-search-names").click(function () {
-    var name = $('.school-name-search input').val();
-    console.log("looking for...");
-    console.log(name);
-    app.findByName(name);
-  });
-
-  $(".btn.search").click(function (e) {
-    e.preventDefault();
-
-    var $btn = $(this);
-    // $(e.target).html('Working&hellip;');
-    $btn.data('default-text', $btn.html());
-    $btn.data('default-bgcolor', $btn.css('background-color'));
-
-    // Use Search button as status
-    $btn.html('Working&hellip;');
-    $btn.css('background-color', 'gray');
-
-
-    // Geocode address then show results
-    app.geocodeAddress(app.getResults);
-
-  });
-
-  $("#address").keyup(function (event) {
-    if (event.keyCode === 13) {
-      $(".btn.search").click();
-    }
-  });
-});
-
-app.findByName = function (name) {
-
-  // Find schools by name
-  var query = "SELECT b.the_geom AS catchment_geom, s.* " +
-              "FROM " + app.db.points + " AS s " +
-              "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
-              "ON s.school_code = b.school_code " +
-              "WHERE s.school_name ILIKE '%" + name + "%'";
-  app.sql.execute(query)
-    .done(function (data) {
-      if (data.rows.length < 1) {
-        console.log("No luck; go fish!");
-      } else {
-        // data.rows.forEach(mapRow);
-        data.rows.forEach(function (data) {
-          console.log("found school");
-          console.log(data);
-        });
-      }
-    });
-};
-
-// update results for a specific lat/lng
-app.getResults = function () {
-
-  // clean up any previous result
-  $('#results-container .result').remove();
-  $('#results-container').empty();
   app.maps = [];
+  app.sql = new cartodb.SQL({ user: app.db.user });
 
-  var lat = app.lat;
-  var lng = app.lng;
-  var alreadyScrolled = false;
+  $(document).ready(function () {
 
+    // Make school level buttons equal width
+    var maxWidth = Math.max.apply(null, $('.block-intro .btn.school-level').map(function () {
+      return $(this).outerWidth(true);
+    }).get());
+    $('.block-intro .btn.school-level').width(maxWidth);
 
-  var resetSearchBtn = function () {
-    // Reset Search button
-    var $btn = $('.btn.search');
-    $btn.text($btn.data('default-text')).css('background-color', $btn.data('default-bgcolor'));
-  };
+    var clickSchoolType = function (e) {
+      e.preventDefault();
+      app.level = e.data.level;
+      // jump to the address search
+      $('html, body').animate({
+        scrollTop: $(".block-address").offset().top - 100 //HACK to center in window.
+      }, 500);
+    };
 
-  var scrollToMap = function ($el) {
-    // scroll to first result
-    $('html, body').animate({
-      scrollTop: $el.offset().top,
-    }, 500, function () {
-      resetSearchBtn();
+    $(".btn.primary").click({level: 'primary'}, clickSchoolType);
+    $(".btn.secondary").click({level: 'secondary'}, clickSchoolType);
+
+    $("#button-search-names").click(function () {
+      var name = $('.school-name-search input').val();
+      console.log("looking for...");
+      console.log(name);
+      app.findByName(name);
     });
-  };
 
-  var mapRow = function (row, i) {
-    var context, source, template, html, mapID, schoolsSQL, catchmentsSQL;
-    var resultID = "result-" + i;
-    mapID = "cartodb-map-" + i;
-    $('#results-container').append('<div class="result" id="' + resultID + '"></div>');
+    $(".btn.search").click(function (e) {
+      e.preventDefault();
 
-    context = app.School.toTemplateContext(row, i);
+      var $btn = $(this);
+      // $(e.target).html('Working&hellip;');
+      $btn.data('default-text', $btn.html());
+      $btn.data('default-bgcolor', $btn.css('background-color'));
 
-    source = $("#result-template").html();
-    template = Handlebars.compile(source);
-    html = template(context);
-    var $result = $('#' + resultID);
-    $result.html(html);
+      // Use Search button as status
+      $btn.html('Working&hellip;');
+      $btn.css('background-color', 'gray');
 
-    schoolsSQL = "SELECT * FROM " + app.db.points + " WHERE school_code = '" + row.school_code + "'";
-    catchmentsSQL = "SELECT * FROM " + app.db.polygons + " WHERE school_type ~* '" + app.level + "' AND school_code = '" + row.school_code + "'";
-    var map = app.addMap(mapID, schoolsSQL, catchmentsSQL, row);
 
-    // Specify a Maki icon name, hex color, and size (s, m, or l).
-    // An array of icon names can be found in L.MakiMarkers.icons or at https://www.mapbox.com/maki/
-    // Lowercase letters a-z and digits 0-9 can also be used. A value of null will result in no icon.
-    // Color may also be set to null, which will result in a gray marker.
-    var icon = L.MakiMarkers.icon({icon: "school", color: "#d72d6c", size: "m"});
-    L.marker([row.latitude, row.longitude], {icon: icon})
-      .addTo(map.map)
-      // note we're using a bigger offset on the popup to reduce flickering;
-      // since we hide the popup on mouseout, if the popup is too close to the marker,
-      // then the popup can actually sit on top of the marker and 'steals' the mouse as the cursor
-      // moves near the edge between the marker and popup, making the popup flicker on and off.
-      .bindPopup("<b>" + row.school_name + "</b>", {offset: [0, -28]})
-      .on('mouseover', Map.onMouseOverOut)
-      .on('mouseout', Map.onMouseOverOut);
+      // Geocode address then show results
+      app.geocodeAddress(app.getResults);
 
-    if (i === 0) { scrollToMap($result); }
-  };
+    });
 
-  // Find schools whose catchment area serves a specific point
-  app.sql.execute("SELECT b.school_code, b.shape_area, s.* FROM " + app.db.polygons + " AS b JOIN " + app.db.points + " AS s ON b.school_code = s.school_code WHERE ST_CONTAINS(b.the_geom, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)) AND b.school_type ~* '" + app.level + "'")
-    .done(function (data) {
-      if (data.rows.length < 1) {
-        // this location isn't within any catchment area. Try searching for schools within 100 KM (TODO)
-        // currently, X nearest.
-        app.sql.execute(
-          "SELECT s.*, " +
-            "ST_DISTANCE(s.the_geom::geography, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)::geography) AS dist " +
-            "FROM " + app.db.points + " AS s " +
-            "WHERE (s.level_of_schooling ~* '" + app.level + "' OR s.level_of_schooling ~* 'central') " +
-            "AND ST_DISTANCE(s.the_geom::geography, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)::geography) < " + app.config.maxRuralTravel +
-            "ORDER BY dist ASC LIMIT 5 "
-        ).done(function (data) {
-          console.log(data);
-          if (data.rows.length < 1) {
-            resetSearchBtn();
-            $('#noResultsModal').modal();
-          }
-          data.rows.forEach(mapRow);
-        });
-      } else {
-        data.rows.forEach(mapRow);
+    $("#address").keyup(function (event) {
+      if (event.keyCode === 13) {
+        $(".btn.search").click();
       }
     });
-};
+  });
+
+  app.findByName = function (name) {
+
+    // Find schools by name
+    var query = "SELECT b.the_geom AS catchment_geom, s.* " +
+                "FROM " + app.db.points + " AS s " +
+                "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
+                "ON s.school_code = b.school_code " +
+                "WHERE s.school_name ILIKE '%" + name + "%'";
+    app.sql.execute(query)
+      .done(function (data) {
+        if (data.rows.length < 1) {
+          console.log("No luck; go fish!");
+        } else {
+          // data.rows.forEach(mapRow);
+          // data.rows.forEach(function (data) {
+          //   console.log("found school");
+          //   console.log(data);
+          // });
+        }
+      });
+  };
+
+  // update results for a specific lat/lng
+  app.getResults = function () {
+
+    // clean up any previous result
+    $('#results-container .result').remove();
+    $('#results-container').empty();
+    app.maps = [];
+
+    var lat = app.lat;
+    var lng = app.lng;
+
+    var resetSearchBtn = function () {
+      // Reset Search button
+      var $btn = $('.btn.search');
+      $btn.text($btn.data('default-text')).css('background-color', $btn.data('default-bgcolor'));
+    };
+
+    var scrollToMap = function ($el) {
+      // scroll to first result
+      $('html, body').animate({
+        scrollTop: $el.offset().top,
+      }, 500, function () {
+        resetSearchBtn();
+      });
+    };
+
+    var mapRow = function (row, i) {
+      var context, source, template, html, mapID, schoolsSQL, catchmentsSQL;
+      var resultID = "result-" + i;
+      mapID = "cartodb-map-" + i;
+      $('#results-container').append('<div class="result" id="' + resultID + '"></div>');
+
+      context = app.School.toTemplateContext(row, i);
+      source = $("#result-template").html();
+      template = Handlebars.compile(source);
+      html = template(context);
+      var $result = $('#' + resultID);
+      $result.html(html);
+
+      schoolsSQL = "SELECT * FROM " + app.db.points + " WHERE school_code = '" + row.school_code + "'";
+      catchmentsSQL = "SELECT * FROM " + app.db.polygons + " WHERE school_type ~* '" + app.level + "' AND school_code = '" + row.school_code + "'";
+      var map = app.addMap(mapID, schoolsSQL, catchmentsSQL, row);
+
+      // Specify a Maki icon name, hex color, and size (s, m, or l).
+      // An array of icon names can be found in L.MakiMarkers.icons or at https://www.mapbox.com/maki/
+      // Lowercase letters a-z and digits 0-9 can also be used. A value of null will result in no icon.
+      // Color may also be set to null, which will result in a gray marker.
+      var icon = L.MakiMarkers.icon({icon: "school", color: "#d72d6c", size: "m"});
+      L.marker([row.latitude, row.longitude], {icon: icon})
+        .addTo(map.map)
+        // note we're using a bigger offset on the popup to reduce flickering;
+        // since we hide the popup on mouseout, if the popup is too close to the marker,
+        // then the popup can actually sit on top of the marker and 'steals' the mouse as the cursor
+        // moves near the edge between the marker and popup, making the popup flicker on and off.
+        .bindPopup("<b>" + row.school_name + "</b>", {offset: [0, -28]})
+        .on('mouseover', Map.onMouseOverOut)
+        .on('mouseout', Map.onMouseOverOut);
+
+      if (i === 0) { scrollToMap($result); }
+    };
 
 
-app.addMap = function (id, schoolsSQL, catchmentsSQL, row) {
+    // Find schools whose catchment area serves a specific point
+    app.sql.execute("SELECT b.school_code, b.shape_area, s.* FROM " + app.db.polygons + " AS b JOIN " + app.db.points + " AS s ON b.school_code = s.school_code WHERE ST_CONTAINS(b.the_geom, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)) AND b.school_type ~* '" + app.level + "'")
+      .done(function (data) {
+        if (data.rows.length < 1) {
+          // this location isn't within any catchment area. Try searching for schools within 100 KM (TODO)
+          // currently, X nearest.
+          app.sql.execute(
+            "SELECT s.*, " +
+              "ST_DISTANCE(s.the_geom::geography, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)::geography) AS dist " +
+              "FROM " + app.db.points + " AS s " +
+              "WHERE (s.level_of_schooling ~* '" + app.level + "' OR s.level_of_schooling ~* 'central') " +
+              "AND ST_DISTANCE(s.the_geom::geography, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)::geography) < " + app.config.maxRuralTravel +
+              "ORDER BY dist ASC LIMIT 5 "
+          ).done(function (data) {
+            console.log(data);
+            if (data.rows.length < 1) {
+              resetSearchBtn();
+              $('#noResultsModal').modal();
+            }
+            data.rows.forEach(mapRow);
+          });
+        } else {
+          data.rows.forEach(mapRow);
+        }
+      });
+  };
 
-  catchmentsSQL = catchmentsSQL || "SELECT * FROM " + app.db.polygons + " WHERE ST_CONTAINS(the_geom, ST_SetSRID(ST_Point(" + app.lng + "," + app.lat + "),4326)) AND school_type ~* '" + app.level + "'";
 
-  var m = new Map(id, schoolsSQL, catchmentsSQL, row);
-  app.maps.push(m);
-  return m;
-};
+  app.addMap = function (id, schoolsSQL, catchmentsSQL, row) {
+
+    catchmentsSQL = catchmentsSQL || "SELECT * FROM " + app.db.polygons + " WHERE ST_CONTAINS(the_geom, ST_SetSRID(ST_Point(" + app.lng + "," + app.lat + "),4326)) AND school_type ~* '" + app.level + "'";
+
+    var m = new Map(id, schoolsSQL, catchmentsSQL, row);
+    app.maps.push(m);
+    return m;
+  };
+
+}());

--- a/js/app.js
+++ b/js/app.js
@@ -80,6 +80,7 @@ app = app || {};
         resetSearchBtn();
         if (data.rows.length < 1) {
           console.log("No luck; go fish!");
+          $('#noResultsForNameModal').modal();
         } else {
           // data.rows.forEach(mapRow);
           // data.rows.forEach(function (data) {
@@ -192,7 +193,7 @@ app = app || {};
             console.log(data);
             if (data.rows.length < 1) {
               resetSearchBtn();
-              $('#noResultsModal').modal();
+              $('#noResultsForAddressModal').modal();
             }
             data.rows.forEach(mapRow);
           });

--- a/js/app.js
+++ b/js/app.js
@@ -89,7 +89,7 @@ app = app || {};
   app.findByName = function (name) {
 
     // Find schools by name
-    var query = "SELECT b.the_geom AS catchment_geom, s.* " +
+    var query = "SELECT b.the_geom AS catchment_geom, b.shape_area, s.* " +
                 "FROM " + app.db.points + " AS s " +
                 "LEFT OUTER JOIN " + app.db.polygons + " AS b " +
                 "ON s.school_code = b.school_code " +

--- a/js/app.js
+++ b/js/app.js
@@ -117,7 +117,7 @@ app.getResults = function () {
     if (i === 0) { scrollToMap($result); }
   };
 
-
+  // Find schools whose catchment area serves a specific point
   app.sql.execute("SELECT b.school_code, b.shape_area, s.* FROM " + app.db.polygons + " AS b JOIN " + app.db.points + " AS s ON b.school_code = s.school_code WHERE ST_CONTAINS(b.the_geom, ST_SetSRID(ST_Point(" + lng + "," + lat + "),4326)) AND b.school_type ~* '" + app.level + "'")
     .done(function (data) {
       if (data.rows.length < 1) {

--- a/js/app.js
+++ b/js/app.js
@@ -102,10 +102,6 @@ app = app || {};
           $('#noResultsForNameModal').modal();
         } else {
           data.rows.forEach(mapRow);
-          // data.rows.forEach(function (data) {
-          //   console.log("found school");
-          //   console.log(data);
-          // });
         }
       }).error(function (errors) {
         resetSearchBtn();

--- a/js/app.js
+++ b/js/app.js
@@ -55,10 +55,17 @@ app = app || {};
     var $result = $('#' + resultID);
     $result.html(html);
 
+    // school level may be unspecified (if just searching by school name)
+    // allow for that
+    var levelFilter = '';
+    if (app.level) {
+      levelFilter = "school_type ~* '" + app.level + "' AND ";
+    }
+
     schoolsSQL = "SELECT * FROM " + app.db.points + " " +
                  "WHERE school_code = '" + row.school_code + "'";
     catchmentsSQL = "SELECT * FROM " + app.db.polygons + " " +
-                 "WHERE school_type ~* '" + app.level + "' AND school_code = '" + row.school_code + "'";
+                 "WHERE " + levelFilter + "school_code = '" + row.school_code + "'";
     var map = app.addMap(mapID, schoolsSQL, catchmentsSQL, row);
 
     // Specify a Maki icon name, hex color, and size (s, m, or l).

--- a/js/app.js
+++ b/js/app.js
@@ -55,8 +55,10 @@ app = app || {};
     var $result = $('#' + resultID);
     $result.html(html);
 
-    schoolsSQL = "SELECT * FROM " + app.db.points + " WHERE school_code = '" + row.school_code + "'";
-    catchmentsSQL = "SELECT * FROM " + app.db.polygons + " WHERE school_type ~* '" + app.level + "' AND school_code = '" + row.school_code + "'";
+    schoolsSQL = "SELECT * FROM " + app.db.points + " " +
+                 "WHERE school_code = '" + row.school_code + "'";
+    catchmentsSQL = "SELECT * FROM " + app.db.polygons + " " +
+                 "WHERE school_type ~* '" + app.level + "' AND school_code = '" + row.school_code + "'";
     var map = app.addMap(mapID, schoolsSQL, catchmentsSQL, row);
 
     // Specify a Maki icon name, hex color, and size (s, m, or l).

--- a/js/app.js
+++ b/js/app.js
@@ -37,7 +37,6 @@ app = app || {};
       e.preventDefault();
 
       var $btn = $(this);
-      // $(e.target).html('Working&hellip;');
       $btn.data('default-text', $btn.html());
       $btn.data('default-bgcolor', $btn.css('background-color'));
 

--- a/js/app.js
+++ b/js/app.js
@@ -101,7 +101,7 @@ app = app || {};
           console.log("No luck; go fish!");
           $('#noResultsForNameModal').modal();
         } else {
-          // data.rows.forEach(mapRow);
+          data.rows.forEach(mapRow);
           // data.rows.forEach(function (data) {
           //   console.log("found school");
           //   console.log(data);

--- a/js/app.js
+++ b/js/app.js
@@ -27,6 +27,10 @@ app = app || {};
   // Put Search button in 'Working' (show status) state
   var setSearchBtnToWorking = function () {
     var $btn = getSearchBtn();
+
+    // if we're already working, our work here is done.
+    if ($btn.html().indexOf('Working') !== -1) { return; }
+
     $btn.data('default-text', $btn.html());
     $btn.data('default-bgcolor', $btn.css('background-color'));
     $btn.html('Working&hellip;');

--- a/js/map.js
+++ b/js/map.js
@@ -60,9 +60,17 @@ Map.prototype.loadNearby = function () {
 
 Map.prototype.init = function () {
 
+  // center on either user's location or selected school
+  var center = null;
+  if (app.lat && app.lng) {
+    center = [app.lat, app.lng];
+  } else if (this.row.latitude && this.row.longitude) {
+    center = [this.row.latitude, this.row.longitude];
+  }
+
   // initiate leaflet map
   var map = new L.Map(this.mapID, {
-    center: [app.lat, app.lng],
+    center: center,
     zoom: 12,
     scrollWheelZoom: false,
   });

--- a/js/map.js
+++ b/js/map.js
@@ -108,7 +108,7 @@ Map.prototype.init = function () {
           app.lng = e.latlng.lng;
 
           // reverse geocode to grab the selected address, then get results.
-          app.reverseGeocode(app.getResults);
+          app.reverseGeocode(app.findByLocation);
         }
       });
 
@@ -122,7 +122,7 @@ Map.prototype.init = function () {
         app.lat = ll.lat;
         app.lng = ll.lng;
         // reverse geocode to grab the selected address, then get results.
-        app.reverseGeocode(app.getResults);
+        app.reverseGeocode(app.findByLocation);
       };
 
       // add a 'home' looking icon to represent the user's location

--- a/js/map.js
+++ b/js/map.js
@@ -134,13 +134,15 @@ Map.prototype.init = function () {
       };
 
       // add a 'home' looking icon to represent the user's location
-      var icon = L.MakiMarkers.icon({icon: "building", color: "#39acc9", size: "m"});
-      var marker = L.marker([app.lat, app.lng], {icon: icon, draggable: true})
-                    .addTo(map)
-                    .on('dragend', onMarkerDragEnd);
-      if (app.showHomeHelpPopup) {
-        marker.bindPopup("<b>Your location (draggable)</b>")
-              .openPopup();
+      if (app.lat && app.lng) {
+        var icon = L.MakiMarkers.icon({icon: "building", color: "#39acc9", size: "m"});
+        var marker = L.marker([app.lat, app.lng], {icon: icon, draggable: true})
+                      .addTo(map)
+                      .on('dragend', onMarkerDragEnd);
+        if (app.showHomeHelpPopup) {
+          marker.bindPopup("<b>Your location (draggable)</b>")
+                .openPopup();
+        }
       }
       // that.marker = marker;
 
@@ -150,7 +152,7 @@ Map.prototype.init = function () {
         app.sql.getBounds(that.catchmentsSQL).done(function (bounds) {
           that.map.fitBounds(bounds);
         });
-      } else {
+      } else if (app.lat && app.lng) {
         // zoom to fit selected school + user location
         var southWest = L.latLng(that.row.latitude, that.row.longitude);
         var northEast = L.latLng(app.lat, app.lng);

--- a/js/school.js
+++ b/js/school.js
@@ -46,6 +46,10 @@ app = app || {};
       email: fields.school_email,
       homeAddress: app.address,
       distance: function () {
+        // We don't always have a user location
+        // (e.g. if searching for a specific school)
+        // That's OK, return nothing in that case.
+        if (!app.lat || !app.lng) { return; }
 
         // function roundToTwo(num) {
         //   return +(Math.round(num + "e+2")  + "e-2");


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1072292/6751173/416880ca-cf55-11e4-8ca2-93a86f7572a8.png)

This fixes #13 (find school by name). We may want to add an autocomplete option, but that may be nontrivial and is outside the scope of #13, so we can file a separate issue for that functionality. 

Notable changes:

* Changes the UI to add text field and search button
* I moved the disclaimer bit below, and lowered it in the visual hierarchy. Just seemed to look better that way.
* New modal, `#tooManyResultsModal`, that pops up when there will be too many results (72ee2c739b49f63ad0b826fbd19cbd5bc993c617)
* New modal for when we have zero results from the name search (`#noResultsForNameModal`); it is similar to the modal we had previously (`#noResultsForAddressModal`) but it says nothing of the user's location or of distance options. (fe492351ad475d3ec1a1a11d610bf16f6a7efd25)
* changes to the map related code to remove the expectation that we'll have the user's location (on the front end, that means you wont see a little house marker when you search by school name)
* The template for school results was changed to only show distance-from-user-to-school and info about the user's location if we actually have that (so, not displayed for name search). 3125470d1fd9c22f497bdc3b9c57a968be47cca3 and d8060f2650256a9aec18dce06f0ffa9962a30a7a
* a bunch of small refactors and some code cleanup for readability, passing jslint, etc.

Old UI:
![image](https://cloud.githubusercontent.com/assets/1072292/6751158/2fa8fa68-cf55-11e4-9d71-2bf8bf2c4af1.png)