### PR TITLE
Changed text in search

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
 
       <div class="jumbotron block-address">
         <h1>I live at:</h1>
-        <p class="lead">Provide an address so we can look up nearby schools:</p>
-        <p><input id="address" type="text" class="form-control" placeholder="Home address" data-google-places=true/></p>
+        <p class="lead">Provide your location so we can look up nearby schools:</p>
+        <p><input id="address" type="text" class="form-control" placeholder="Home address, suburb or postcode" data-google-places=true/></p>
         <a id="button-search-address" class="btn btn-lg btn-success search" href="#" role="button">Search</a>
       </div>
 


### PR DESCRIPTION
Changed 'address' to 'location' and placeholder text in search bar from 'home addres' to 'home address, suburb or postcode'.

Clarifies to end user scope of tool. Fixes #34