### PR TITLE
hide address field unless needed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,6 +74,7 @@ ul.school-details {
 }
 
 .block-address {
+	display: none;
 	margin-top: 25em;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -177,6 +177,7 @@ app = app || {};
       e.preventDefault();
       app.level = e.data.level;
       // jump to the address search
+      $(".block-address").show();
       $('html, body').animate({
         scrollTop: $(".block-address").offset().top - 100 //HACK to center in window.
       }, 500);
@@ -200,6 +201,7 @@ app = app || {};
         console.log('nothing entered to search for, not trying!');
         setTimeout(function () {resetSearchBtn(); }, 200);
       } else {
+        $('.block-address').hide();
         app.findByName(name);
       }
     });


### PR DESCRIPTION
- address search box is only needed if we’re searching by level
- address search box should be hidden if we’ve done a school name search

Fixes #29