### PR TITLE
enrolment trend -> just enrolment

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
                 </p>
               </li>
               {{/if}}
-              <li class="school-enrollment"><span class="field-label">Enrolment trends: </span><span class="field-data"><a href="http://172.31.64.43:8000/views/NSW_NSSC_Dashboard/DashboardNSSCEnrolments?Deewr%20Id=4921" target="_blank">See CESE Data</a></span></li>
+              <li class="school-enrollment"><span class="field-label">Enrolment: </span><span class="field-data">{{student_number}}</span></li>
               <div style="display:none">
               <li class="school-established"><span class="field-label">Established: </span><span class="field-data">{{established}}</span></li></div>
 


### PR DESCRIPTION
Because the enrolment number tells people the most at a glance.
- We can add the other info in again later.
- Fixes #96
