### PR TITLE
Make location text more specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         <h1>I live at:</h1>
         <p class="lead">Provide your location so we can look up nearby schools:</p>
         <p>
-          <input id="address" type="text" class="form-control" placeholder="Home address, suburb or postcode" data-google-places=true/></p>
+          <input id="address" type="text" class="form-control" placeholder="Please enter your home address..." data-google-places=true/></p>
           <a id="button-search-address" data-input="address" class="btn search" href="#" role="button">Search</a>
       </div>
 


### PR DESCRIPTION
Edited placeholder text in location section. When we tested the app with
a user, there were issues with inputting a postcode rather then a full
address. To get accurate results, a full address is needed. This text
will encourage users to enter that information. We also added an
ellipses to be consistent in style with the search by school name
section.
- 'home address, suburb or postcode' -> 'please enter your home
  address...'
