### PR TITLE
make autocomplete behave in standard way

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -35,12 +35,8 @@ app.util = app.util || {};
         haveResponses = true;
       });
       if (haveResponses) {
-        if (data.rows.length === 1) { // exact match found
-          $input.autocomplete("close");
-          $input.val(data.rows[0].school_name);
-        } else {  // show suggestions
-          response(autocompleteResponses);
-        }
+        // show suggestions
+        response(autocompleteResponses);
       } else {
         $input.autocomplete("close");
       }


### PR DESCRIPTION
Previously if there was just one result in the autocomplete list, we filled in the text input field and closed the autocomplete list. That was unexpected for users. 
- Fixes #103
