### PR TITLE
Fixes #135 (“Central schools without catchments not appearing in results”)

### DIFF
--- a/js/query.js
+++ b/js/query.js
@@ -136,7 +136,7 @@ app = app || {};
   // accepts either a single type e.g. "primary" or multiple, e.g. ['primary', 'community']
   Query.prototype.setSchoolType = function (typeOrTypes, exact_type_search) {
 
-    var exact = exact_type_search || true;
+    var exact = (exact_type_search === undefined ? false : exact_type_search);
 
     var type, otherTypes, otherTypesExpression = '';
 


### PR DESCRIPTION
Fixed bug in setSchoolType() 

The previous code didn’t live up to the description
of what this function should do: if exact_type_search
wasn’t set (as is the case in app.findByLocation()), 
the function was running an exact school type search when
really it should have been running the “inexact” search.
That is, when we search for primary schools, it was searching
for exactly that, but we actually need it to search for 
community schools as well.

Fixes #135 (“Central schools without catchments not appearing in results”)
