### PR TITLE
don't scroll+center when we don't need to

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -245,9 +245,6 @@ app = app || {};
 	if (school_code){
 		app.findBySchoolCode(school_code);
 	}
-	else{
-		app.ui.scrollAndCenter('.block-intro');
-	}
   });
 
 }());


### PR DESCRIPTION
Fixes #184
- when we first load app, we should need to scroll to .block-intro (it's at the top)
- elsewhere in a previous commit we changed the code so it doesn't reload the page when 'new search' button is clicked (it just scrolls to the top instead), so this code here just removes the now unnecessary scrolling bit.
