### PR TITLE
fix filters when user hasn't provided address

### DIFF
--- a/js/views/mapview.js
+++ b/js/views/mapview.js
@@ -227,10 +227,17 @@ app = app || {};
 		  
         console.log("No results visible; re-doing search and zooming...");
         var q2 = new app.Query();
+
+        // If user hasn't provided their location yet, center our search
+        // on the school they must have searched for.
+        var lat = app.lat || app.schoolView.school.latitude;
+        var lng = app.lng || app.schoolView.school.longitude;
+        if (!lat || !lng) { console.log("yikes, we've got no lat/lng to search around!") }
+
         q2.setSchoolType(type, true).setSupport(app.support_needed)
           .where("s.school_code NOT IN (" +  _.pluck(that.schools.schools, 'school_code') + ")")
           .setLimit(1)
-          .byClosest(app.lat, app.lng); // assumption: we have lat/lng, TODO: test w/o user address
+          .byClosest(lat, lng);
         if (app.state.nearby.filterFeatureForType[app.state.nearby.type] && app.state.nearby.filterFeatureForType[app.state.nearby.type].sql) { // add custom filter if it has been set
           q2.where(app.state.nearby.filterFeatureForType[app.state.nearby.type].sql);
         }
@@ -246,7 +253,7 @@ app = app || {};
           var markers = addMarkers(that, data);
 
           // fit view of map to user location + results
-          var homeMarker = L.marker([app.lat, app.lng], {icon: app.geo.homeIcon});
+          var homeMarker = L.marker([lat, lng], {icon: app.geo.homeIcon});
           markers.push(homeMarker);
           var allMapMarkers = new L.featureGroup(markers);
           that.map.fitBounds(allMapMarkers.getBounds());


### PR DESCRIPTION
if no user location, take school of interest as center for geo queries

From @reekypete:

"where there's no user address (because you just typed the school name in) the query doesn't know how to set the centre of the query.
I've coded a fix to use the school as the centre in this case." https://github.com/CodeforAustralia/school-finder/issues/193#issuecomment-243980070

Code is from @reekypete, just split from previous commit and a little tweak:

```
 var lat = app.lat ? app.lat : app.schoolView.school.latitude;
```

can just be:

```
 var lat = app.lat || app.schoolView.school.latitude;
```

Fixes #193
