### PR TITLE
fix funny chars

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,9 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="tooManyResultsModalLabel">Yikes! There are too many results. &nbsp; Â¯(Â°_o)/Â¯</h4> <!-- other emoji: âŠ™ï¹âŠ™ or âŠ™â–‚âŠ™ -->
+            <h4 class="modal-title" id="tooManyResultsModalLabel">Yikes! There are too many results. &nbsp; &#x1F62F; &#x1F61E; </h4>
+            <!-- 😯😞 or hushed face (U+1F62F) followed by disappointed face (U+1F61E). -->
+
           </div>
           <div class="modal-body">
             <p>I found <span class="results-count">way too many</span> results and can't display them all. Feel free to try another search though!</p>


### PR DESCRIPTION
Fixes funny character issues mentioned in #185 and #186 (which are really duplicates), #212 and #213.

See those issues for problem descriptions and how to test.

I'm using unicode in the comments as you'll see below (to explain what the characters are) but we fix the problem we had before (unicode character values got lost in a file save) and muck up the html) by using html entities (e.g. `&#x1F633;`) to represent the character value w/o relying on unicode bytes.
