### PR TITLE
Make school name field padding only apply on wide enough screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -538,6 +538,11 @@ input#nearby-girls {
 	.block-intro .btn.school-level {
 		width: 42%; /* Make school level buttons equal width */
 	}
+
+    .school-name-search {
+        margin-right: 2em;
+        margin-left: 2em;
+    }
 }
 
 .school-level-definition {
@@ -621,11 +626,6 @@ input#nearby-girls {
     border: none;
 }
 
-
-.school-name-search {
-	margin-right: 2em;
-	margin-left: 2em;
-}
 
 @media only screen and (min-width: 980px) {
 	.school-name {


### PR DESCRIPTION
Fixes #231

Should now look like this on small screens:

![image](https://cloud.githubusercontent.com/assets/1072292/18979658/7e260270-8729-11e6-8c5e-b8b2949a9772.png)
