### PR TITLE
update breakpoint for new(ish) text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -539,7 +539,7 @@ input#nearby-girls {
 	margin-bottom: 0.5em; /* vertically separate buttons on narrow screens */
 	width: 100%;
 }
-@media (min-width: 570px) { /* breaks at < 570px */
+@media (min-width: 620px) { /* layout breaks below this point for two buttons side by side  */
 	.block-intro .btn.school-level {
 		width: 42%; /* Make school level buttons equal width */
 	}


### PR DESCRIPTION
- when we switched 1st screen button text from 'primary school' to 'primary aged student',
  we didn't also update this breakpoint (the wider text on the two buttons means
  the layout breaks at a wider point).
- Fixes #247
