### PR TITLE
fixes/262 - App scrolls down on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,17 @@
 
   ga('create', 'UA-63141018-1', 'auto');
   ga('send', 'pageview');
-
+  
+  $(document).ready(function() {
+	  // do not remove - fixes weird scrolling bug
+	  var timeout = setTimeout(function(){ 
+		  if (document.activeElement.id == "body"){
+			  $("#dept-logo").focus();
+			  $("#schoolname").focus();
+			  clearTimeout(timeout);	
+		  }
+	  }, 1);
+	});
 </script>
 
 


### PR DESCRIPTION
Bug occurs when focus shifts to body element. Setting tabindex=-1 doesn't reliably fix it so I've coded a brute force solution
