### PR TITLE
fix text shadow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -280,7 +280,7 @@ a:focus .fa-stack-1x {
 	color: #707070;
 	margin-top: 0.25em;
 }
-.school-info .field-label {
+.school-details .field-label {
 	color: rgb(189, 239, 252); /* based on background blue but lighter for readability */
 	text-shadow: 0px 0px 1px #3e3e3e;
 	font-weight: bold;


### PR DESCRIPTION
- Fixes #273
- Makes style apply to a more specifical and correct class (the details section only, not the 'About' text as shown in #273). 
