### PR TITLE
fixes/266-new-google-key-cleaned

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA-OOmUXx24cznMjeed3M-Gmjj_oOZrqbQ&libraries=places"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAKM6jWsiW7J3-jBA-27rf-O6rRyIy7yqI&libraries=places"></script>
     <script src="js/vendor/jquery-ui/jquery-ui.js"></script> <!-- for autocomplete -->
     <!-- script src="js/vendor/cartodb.js"></script-->
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.12/cartodb.js"></script>


### PR DESCRIPTION
Fixes #266 new-google-key-cleaned

D of E has purchased an Enterprise license for Google Maps. This provides 1,000,000 Maps API Credits, and in addition offers graceful degradation when limits are exceeded (i.e. we will be contacted by Google and warned).

We cannot be sure how many people will use the school finder, particularly when it is first released. This license offers greater capacity and certainty than the existing (free) license.
