### PR TITLE
(cherry-pick) Always show support info #137

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -352,11 +352,11 @@ ul.school-details {
 .jumbotron h1 {
 	font-weight: 200;
 }
-.school-details .school-support li {
-	margin-left: 2em;
+.school-details .school-support ul {
+  margin-left: 1em;
 }
-.school-support p.overview {
-	margin: 1em 0 0 1em;
+.school-details .school-support li {
+	margin-left: 1em;
 }
 
 .school-details li {

--- a/index.html
+++ b/index.html
@@ -312,24 +312,14 @@
               {{#if is_selective_possible}} {{#if is_somewhat_selective}}
               <li class="school-selective"><span class="field-label">Academically selective: </span><span class="field-data">{{selective_school}}</span></li>
               {{/if}} {{/if}}
-              {{#if support_offered}}
               <li class="school-support">
-                <span class="field-label">Support for:</span>
+                <span class="field-label">Special learning needs support:</span>
                 <ul>
-                {{#each support_offered}}
-                  <li>{{long_description}}</li>
-                {{/each}}
-                </ul>
-                <p class="overview">Support info:
-                  <ul>
                   <li>contact this school</li>
                   <li><a href="http://www.schools.nsw.edu.au/studentsupport/programs/disability.php">see general support overview</a></li>
-                  </ul>
-                </p>
+                </ul>
               </li>
-              {{/if}}
               <li class="school-enrollment"><span class="field-label">Enrolment: </span><span class="field-data">{{round student_number}}</span></li>
-
               <div style="display:none">
               <li class="school-established"><span class="field-label">Established: </span><span class="field-data">{{established}}</span></li></div>
 


### PR DESCRIPTION
Since #137 calls for removing ability to say whether
we’re looking for support, we need always show the support overview.

* This is result of `git cherry-pick 87afdde06e786bac7063dea680d92346c8da0231` and merging the conflict.
* Fixes #282.

* Note incorporation of rounding student enrolment number (added after the original commit),
* and fixing margin for school support (affected by this change https://github.com/CartoDB/cartodb.js/commit/2a84b4d1e77d7f1d11d7b7c07b079223aa696610)

* Suggests users looking for special support "contact this school" for all schools (including SSPs) -- see discussion in #282 