### PR TITLE
fixes nearby schools map control's select box on firefox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -411,10 +411,6 @@ ul.school-details {
    -moz-appearance: none;
     border-radius: 2px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-   -webkit-padding-end: 20px;
-   -moz-padding-end: 20px;
-   -webkit-padding-start: 2px;
-   -moz-padding-start: 2px;
     background-image: url(http://i62.tinypic.com/15xvbd5.png), -webkit-linear-gradient(#FAFAFA, #F4F4F4 40%, #E5E5E5);
    background-position: 97% center;
    background-repeat: no-repeat;
@@ -423,7 +419,7 @@ ul.school-details {
    font-size: inherit;
    margin: 20px 0;
    overflow: hidden;
-   padding: 5px 10px;
+   padding: 5px 30px 5px 2px;
    text-overflow: ellipsis;
    white-space: nowrap;
    width: 300px;


### PR DESCRIPTION
* adjusts padding (which overrides -*-padding-start & -*-padding-end anyway)
  so on Firefox, the outline around the selected school type does not extend
  on the right side to cover the drop down arrow

* fixes #292 

On Firefox, should now look like this 

![image](https://cloud.githubusercontent.com/assets/1072292/20655963/7da35aec-b4dc-11e6-9a56-6c578d6ca32e.png)


rather than those reported in #292:

![image](https://cloud.githubusercontent.com/assets/1072292/20646687/f9976f38-b434-11e6-9a04-7b7de0c51eea.png)

(Pay attention to just the outline around 'primary' and 'secondary'.)