### PR TITLE
override default padding for .school-support ul

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -353,6 +353,7 @@ ul.school-details {
 }
 .school-details .school-support ul {
   margin-left: 1em;
+  padding-left: 0;
 }
 .school-details .school-support li {
 	margin-left: 1em;


### PR DESCRIPTION
- somehow missed this when working on https://github.com/CodeforAustralia/school-finder/issues/282, maybe got mungled during merge attempt

- without this, we've got a bunch (I'm seeing browser defaults of 40px in Chrome, FF)
  of padding to the left of the list:

![image](https://cloud.githubusercontent.com/assets/1072292/20662265/97b3ee80-b507-11e6-8f92-3610424944d8.png)

- should now look like this:

![image](https://cloud.githubusercontent.com/assets/1072292/20662276/a3cb8a2a-b507-11e6-80e0-5a39d5656558.png)


- Relates to #282 

