### PR TITLE
reset app state on 'new search'

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
           <div class="col-sm-4 results-footer-btn-column">
             <button type="button" class="btn results-footer-btn">
               <i class="fa fa-long-arrow-up"></i>
-              <span>Scroll to top</span>
+              <span>New search</span>
             </button>
           </div>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -3,18 +3,32 @@ app = app || {};
 (function () {
 
   app.sql = new cartodb.SQL({ user: app.db.user });
-  app.state = {}; // UI and application state.
-  app.state.nearby = {}; // info about nearby markers to display
 
-  // set defaults used by map controls too
-  app.state.nearby.showFilters = false;
-  app.state.nearby.filterFeatureForType = {};
-  app.state.showNearby = null;
-  app.state.nearby.othersForType = {
-    primary: ['infants', 'central'],
-    secondary: ['central'],
+  // UI and application state.
+  app.resetState = function () {
+
+    // Start with empty / default application state
+    app.state = {
+      nearby: { // nearby schools app state & map control defaults
+        showFilters: false,
+        filterFeatureForType: { // TODO: rename to 'featureForType' to be like othersForType
+          primary: { name: 'any' },
+          secondary: { name: 'any' }
+        },
+        othersForType: {
+          primary: ['infants', 'central'],
+          secondary: ['central'],
+        },
+      },
+      showNearby: null,
+    };
+    app.lat = null;
+    app.lng = null;
+    app.activeQuery = null;
+    app.address = null;
   };
 
+  app.resetState();
 
   app.schools = new app.Schools(); // schools results collection
 
@@ -36,9 +50,13 @@ app = app || {};
     // ensure we're not adding same handler repeatedly
     $('.results-footer-btn').off('click.results-footer-btn');
     $('.results-footer-btn').on('click.results-footer-btn', function () {
-      app.util.log('clicked "scroll to top" button');
+      app.util.log('clicked "new search" button');
       var target = '#search-start';
-      app.ui.scrollAndCenter(target);
+      app.ui.clearSearchInputs(); // clear inputs *before* scrolling so user doesn't see it happening
+      app.ui.scrollAndCenter(target, function postScroll () {
+        app.resetState();
+        app.ui.reset(); // will remove map etc, *after* scrolling, so user doesn't see it happening
+      });
     });
 
     // usually (with just one result) we'll want to skip right to the map

--- a/js/geo/MapControls.js
+++ b/js/geo/MapControls.js
@@ -144,13 +144,13 @@
     legend.innerHTML = 'With feature:';
     fieldset.appendChild(legend);
 
-    fieldset.appendChild(optionControl('radio', 'feature', 'any', 'nearby-any2', 'feature', 'Any', (typeof app.state.nearby.filterFeatureForType[app.state.nearby.type] === 'undefined' || app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'any'), radioClick));
-    var boysGirls = optionControl('radio', 'feature', 'boys', 'nearby-boys', 'feature', 'Boys', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'boys': false, radioClick);
-    boysGirls = optionControl('radio', 'feature', 'girls', 'nearby-girls', 'feature', 'Girls', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'girls': false, radioClick, boysGirls);
+    fieldset.appendChild(optionControl('radio', 'feature', 'any', 'nearby-any2', 'feature-secondary', 'Any', (typeof app.state.nearby.filterFeatureForType[app.state.nearby.type] === 'undefined' || app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'any'), radioClick));
+    var boysGirls = optionControl('radio', 'feature', 'boys', 'nearby-boys', 'feature-secondary', 'Boys', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'boys': false, radioClick);
+    boysGirls = optionControl('radio', 'feature', 'girls', 'nearby-girls', 'feature-secondary', 'Girls', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'girls': false, radioClick, boysGirls);
     fieldset.appendChild(boysGirls);
-    fieldset.appendChild(optionControl('radio', 'feature', 'selective', 'nearby-selective', 'feature', 'Academically selective option', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'selective': false, radioClick));
-    fieldset.appendChild(optionControl('radio', 'feature', 'intensive_english', 'nearby-intensive_english_centre', 'feature', 'Intensive English Centre', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'nearby-intensive_english_centre': false, radioClick));
-    fieldset.appendChild(optionControl('radio', 'feature', 'specialty', 'nearby-specialty', 'feature', 'Specialty option', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'nearby-specialty': false, radioClick));
+    fieldset.appendChild(optionControl('radio', 'feature', 'selective', 'nearby-selective', 'feature-secondary', 'Academically selective option', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'selective': false, radioClick));
+    fieldset.appendChild(optionControl('radio', 'feature', 'intensive_english', 'nearby-intensive_english_centre', 'feature-secondary', 'Intensive English Centre', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'nearby-intensive_english_centre': false, radioClick));
+    fieldset.appendChild(optionControl('radio', 'feature', 'specialty', 'nearby-specialty', 'feature-secondary', 'Specialty option', app.state.nearby.filterFeatureForType[app.state.nearby.type] ?  app.state.nearby.filterFeatureForType[app.state.nearby.type].name == 'nearby-specialty': false, radioClick));
 
     return fieldset;
   };
@@ -343,6 +343,7 @@
 
           app.mapView.updateResultsPopups();
           that.updateFilterUI();
+          that.updateFeaturesUI();
           that.updateOptionsUI();
           app.mapView.loadNearby();
         }
@@ -371,13 +372,13 @@
         toggleFilterButton.setAttribute('aria-label', toggleFilterButton.title);
       }
 
+      this.updateFeaturesUI();
       this.updateOptionsUI();
     },
 
     updateFilterUI: function () {
       var container = this.container,
           type = app.state.nearby.type;
-
 
       var support = app.util.support_description();
       var explanation = support && app.support_needed ? '(supporting ' + support + ')' : ''; // app.support_needed
@@ -391,6 +392,27 @@
 
       $(container).find('.nearby-schools-options fieldset.' + type).show();
       $(container).find('.nearby-schools-options fieldset div.' + type).show();
+    },
+
+    updateFeaturesUI: function () {
+      var container = this.container,
+          type = app.state.nearby.type,
+          feature = app.state.nearby.filterFeatureForType[type];
+
+      if (!type || (type != 'primary' && type != 'secondary')) {
+        // only primary, secondary have any features to update;
+        // skip for other school types
+        return;
+      }
+
+      // uncheck all for this type
+      $('.nearby-schools-feature input[name=feature-' + type + ']:radio', container).prop('checked',false);
+
+      // check just the feature stored in app.state
+      // note that one radio button's `value` should matches the feature's `name`.
+      if (feature) {
+        $('.nearby-schools-feature input[name=feature-' + type +'][value=' + feature.name + ']:radio', container).prop('checked', true);
+      }
     },
 
     updateOptionsUI: function () {

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,6 +3,27 @@ app.ui = app.ui || {};
 
 (function () {
 
+  // clear input text fields
+  app.ui.clearSearchInputs = function () {
+    $('.block-intro #schoolname').val('');
+    $('.block-address #address').val('');
+  };
+
+  // return UI to initial state
+  app.ui.reset = function () {
+    app.util.log('resetting UI to initial view');
+
+    app.ui.clearSearchInputs();
+
+    // hide any previous resulting UI components
+    $('.block-address').hide();
+    app.listView.hide();
+    app.mapView.hide();
+    app.schoolView.hide();
+    $('.results-footer').hide();
+
+  }
+
   app.ui.resetSearchBtns = function () {
     var $btns = $('.btn.search');
     $btns.each(function () {
@@ -45,11 +66,15 @@ app.ui = app.ui || {};
   };
 
   // animated scroll to and center element with specified selector
-  app.ui.scrollAndCenter = function (selector) {
+  // will call the (optional) postScrollCallback after scroll completes
+  app.ui.scrollAndCenter = function (selector, postScrollCallback) {
     var vOffset = ($(window).height() - $(selector).outerHeight()) / 2;
     var scrollTop = $(selector).offset().top - (vOffset > 0 ? vOffset : 0);
     $('html, body').animate({scrollTop: scrollTop}, 500, function scrollDone () {
       app.ui.setTabFocus(selector);
+      if (postScrollCallback && typeof postScrollCallback === 'function') {
+        postScrollCallback();
+      }
     });
   };
 
@@ -91,6 +116,7 @@ app.ui = app.ui || {};
         app.util.log('nothing entered to search for, not trying!');
         setTimeout(function () {app.ui.resetSearchBtns(); }, 200);
       } else {
+        app.resetState();
         processInput(inputText);
       }
     };

--- a/js/views/listview.js
+++ b/js/views/listview.js
@@ -9,6 +9,9 @@ app = app || {};
 
   app.ListView = ListView;
 
+  ListView.prototype.hide = function () {
+    this.$el.hide();
+  };
 
   ListView.prototype.update = function (schools) {
 
@@ -34,6 +37,7 @@ app = app || {};
     // clean up any previous result & re-add
     this.$el.empty();
     this.$el.append(html);
+    this.$el.show();
 
     this.$el.find('.btn').click(function (e) {
       var el = $(this);
@@ -58,7 +62,10 @@ app = app || {};
     function jumpToTop(e) {
       e.preventDefault();
       var target = this.hash;
-      app.ui.scrollAndCenter(target);
+      app.ui.scrollAndCenter(target, function postScroll () {
+        app.resetState();
+        app.ui.reset();
+      });
     }
     this.$el.find('.jump-to-start').click(jumpToTop);
 

--- a/js/views/mapview.js
+++ b/js/views/mapview.js
@@ -11,6 +11,10 @@ app = app || {};
 
   app.MapView = MapView;
 
+  MapView.prototype.hide = function () {
+    this.$el.hide();
+  };
+
   MapView.prototype.update = function (schools) {
     this.schools = schools;
     this.render();
@@ -37,6 +41,8 @@ app = app || {};
     }
 
     this.init();
+
+    this.$el.show();
 
     this.rendered = true;
   };

--- a/js/views/schoolview.js
+++ b/js/views/schoolview.js
@@ -10,6 +10,10 @@ app = app || {};
 
   app.SchoolView = SchoolView;
 
+  SchoolView.prototype.hide = function () {
+    this.$el.hide();
+  };
+
   SchoolView.prototype.update = function (schoolOrSchools) {
     if (schoolOrSchools instanceof app.Schools) {
       this.school = schoolOrSchools.selected();
@@ -54,6 +58,7 @@ app = app || {};
     // clean up any previous result & re-add
     this.$el.empty();
     this.$el.append(html);
+    this.$el.show();
 
     if (app.haveUserLocation()) {
       this.insertDistanceToUser();


### PR DESCRIPTION
* fixes #264

* this commit is result of `git cherry-pick 5fbeefc8040a8a45f22a87ea6668c8bcd55f5ba0`
  and merge + extend by Peter W. Original commit was:
  "[fixes/264-If user scrolls back to top to start a new search, results are inconsistent](https://github.com/CodeforAustralia/school-finder/pull/265/commits/925b3ae0931560a3234eafa4c7cb6d4e543d00ed)"
  by Peter O.

Notable changes:

* 'Scroll to top' button is now 'New search' (again)

* During scroll to top, app state is reset and corresponding UI elements are
  reset (aka hidden or emptied)

* app.ui.scrollAndCenter() now takes a callback (optional) to run after
 scrolling (this gets used by the reset code so we can scroll past things
  and then remove them).

* Map control for nearby schools filter now makes sure to update the
  feature associated with a given school level (primary or secondary) -
  previously those radio buttons weren't getting reset in some cases.
  A bunch of 'fieldset.appendChild(...' lines changed because we needed
  a way to select the buttons associated with the school level, so the
  secondary buttons now match the primary in that they have a
  'feature-secondary' name we can select by in updateFeaturesUI().

* new methods:
 app.resetState() -- was in Peter O's code too.
 app.ui.clearSearchInputs()
 app.ui.reset()
 app.listView.hide(); // each of these .hide() methods are used in ui.reset()
 app.mapView.hide();
 app.schoolView.hide(); (and we added $el.show() to compensate in *View.render())