### PR TITLE
fix overflowing long-named option buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -205,6 +205,9 @@ a:focus .fa-stack-1x {
         but we want these spans to look like block elements */
     }
 
+.btn.school-option {
+    white-space: normal; /* override bootstrap .btn: allow long button names to break into multiple lines */
+}
 
 /* A quasi-radio button control with raised buttons inspired by Material Design. */
 /* Unlike a radio button set, you use Tab (vs left/rigth/up/down) to change focus


### PR DESCRIPTION
* override bootstrap .btn: allow long button names to break into multiple lines

* Fixes #315

Should now look like:

![image](https://cloud.githubusercontent.com/assets/1072292/20948357/8f00b300-bbc8-11e6-8f12-8376f2355a1e.png)
