### PR TITLE
fix padding on title for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -669,7 +669,7 @@ ul.school-details {
 @media only screen and (max-width: 320px) {
 	.sitename {
 		font-size: 18px;
-		padding-right: 0;
+		padding-left: 0;
 	}
 	.org-logo img {
 		height: 22px;


### PR DESCRIPTION
* we've moved site title to right side, so need to flip padding
  so that there is padding on right and remove excess on the left.

* (forgot to do this in #242)

* Fixes #314 

Now, with proper padding on title:
![image](https://cloud.githubusercontent.com/assets/1072292/20948454/14429cea-bbc9-11e6-9547-344eb67a1396.png)
