### PR TITLE
Fixes some geocoder failures

### DIFF
--- a/js/geo/google.js
+++ b/js/geo/google.js
@@ -132,13 +132,33 @@ app = app || {};
           });
         },
 
+        // converts to object format similar to that returned by our app.google.Geocoder
+        // inputStr: the text of the input field
+        // placeResult: a google.maps.places.PlaceResult
+        _convertGooglePlaceToAppGeocoderResult: function (inputStr, placeResult) {
+          return {
+            address: inputStr, // or place.formatted_address, ?
+            lat: placeResult.geometry.location.lat(),
+            lng: placeResult.geometry.location.lng(),
+            results: [ // some duplication, yeah. :-/
+              {
+                address: inputStr,
+                lat: placeResult.geometry.location.lat(),
+                lng: placeResult.geometry.location.lng(),
+              }
+            ]
+          };
+        },
+
         initialize: function() {
           googleGeocoder.service = new google.maps.Geocoder();
 
+          // Geocoder API uses `componentRestrictions` & `bounds` options
+          // https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingRequests
+
           googleGeocoder.options = {};
-          var autocompleteOptions = {};
           if (app.config.geocoder.country) {
-        	  autocompleteOptions.componentRestrictions = {
+            googleGeocoder.options.componentRestrictions = {
               country: app.config.geocoder.country
             };
           }
@@ -149,12 +169,36 @@ app = app || {};
             }).getBounds();
           }
 
-          autocompleteOptions = _.extend({}, googleGeocoder.options, {
-            types: ['geocode']
-          },
-          autocompleteOptions);
+          // Places JS API (AutocompleteOptions) uses `componentRestrictions` & `bounds` options
+          // (same as Geocoder API) plus the `types` option which should be either
+          // ['geocode'] or ['address'], see https://developers.google.com/places/supported_types#table3
+          // https://developers.google.com/maps/documentation/javascript/reference#AutocompleteOptions
+
+          var autocompleteOptions = _.extend({}, googleGeocoder.options);
+          autocompleteOptions.types = ['address']; // or ['geocode'];
+
           $('input[data-geocode-autocomplete]').each(function () {
-            new google.maps.places.Autocomplete(this, autocompleteOptions);
+            var input = this;
+            var autocomplete = new google.maps.places.Autocomplete(input, autocompleteOptions);
+
+            google.maps.event.addListener(autocomplete, 'place_changed', function() {
+              var place = autocomplete.getPlace();
+
+              // cache this place in the geocoder results,
+              // as a place search should be at least as accurate as any geocoding result
+              app.geocoder.cacheResult(
+                input.value,
+                googleGeocoder._convertGooglePlaceToAppGeocoderResult(input.value, place)
+              );
+
+              app.util.log('Place input:', input.value);
+              app.util.log('Google Place:', place);
+              app.util.log('Place coordinates:', {
+                lat: place.geometry.location.lat(),
+                lng: place.geometry.location.lng(),
+              });
+            });
+
           });
 
           return googleGeocoder;

--- a/js/geocoder.js
+++ b/js/geocoder.js
@@ -147,6 +147,11 @@ $(function () {
 
       initialize: function () { return cachingGeocoder; },
 
+      // key should be either address:string or '<lng>,<lat>'
+      cacheResult: function (key, data) {
+        cache[key] = data;
+      },
+
       geocode: function (options, success, failure) {
 
         var key;
@@ -169,7 +174,7 @@ $(function () {
           return geocoder.geocode(
             options,
             function cacheOnSuccess(data) {
-              cache[key] = data;
+              cachingGeocoder.cacheResult(key, data);
               success(data);
             },
             failure);


### PR DESCRIPTION
See detailed implementation comment in 4634862f867cbe469c6c9d4df6e4b2525e6d2c7c. 

Should fix #323.

Test: 
* search for 'primary' school
* type in the address given in #323 to the address field
* hit TAB to jump to the search button and click it

Expected result: looks like this
![image](https://cloud.githubusercontent.com/assets/1072292/22460049/18dae9e6-e758-11e6-9671-9b4f6859ad91.png)

Test 2: same as above, but start typing the address and use the autocompleter.