### PR TITLE
removes CESE logo, email for white label sites

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
     <script src="js/vendor/handlebars-v3.0.0.js"></script>
     <script src="js/vendor/Leaflet.MakiMarkers.js"></script>
     <script src="js/config.js"></script>
+    <script src="js/whitelabel.js"></script>
     <script src="js/geo/M.js"></script>
     <script src="js/geo/MapControls.js"></script>
     <script src="js/geo/google.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -323,12 +323,15 @@ app = app || {};
       return false;
     };
 
-    sel += 'To';
-    $(sel).focus(addM);
-    $(sel).focusout(removeM);
+    if (!app.whitelabel) {
+      // not whitelabel, so add our email address
+      sel += 'To';
+      $(sel).focus(addM);
+      $(sel).focusout(removeM);
 
-    $(sel).on('mouseenter', addM);
-    $(sel).on('mouseleave', removeM);
+      $(sel).on('mouseenter', addM);
+      $(sel).on('mouseleave', removeM);
+    }
 
     var school_code = getUrlVars()['school_code'];
     if (school_code){

--- a/js/whitelabel.js
+++ b/js/whitelabel.js
@@ -1,0 +1,14 @@
+app = app || {};
+
+// White Label version
+
+(function() {
+  // bit of a hack for now, but change to false on official site (or don't include this file)
+  // https://github.com/CodeforAustralia/school-finder/issues/349
+  app.whitelabel = true;
+
+  if (app.whitelabel) {
+    // white label version doesn't get official logo
+    $('.org-logo').empty();
+  }
+}());


### PR DESCRIPTION
* Fixes 349

* CESE will want to replace whitelabel.js with an empty file or change
```
  app.whitelabel = true;
```
to
```
  app.whitelabel = false;
```

Removes logo:
![site sans logo](https://cloud.githubusercontent.com/assets/1072292/25785167/da466390-332e-11e7-9405-c25108423035.png)

And changes email links to not resolve to CESE emails. 