### PR TITLE
make secondary catchment fill color match 2ndary icon

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -20,7 +20,7 @@ app = app || {};
     attribution: 'Mapbox <a href="https://mapbox.com/about/maps" target="_blank">Terms &amp; Feedback</a>',
     // CartoCSS for various map layers
     backgroundCSS: '{polygon-fill: #F0F0F0; polygon-opacity: 0; line-color: #7E599D; line-width: 0.3; line-opacity: 1; line-dasharray: 10,4;}',
-    catchmentCSS: '{polygon-fill: rgba(164, 65, 178, 0.15); line-color: #0B6138; line-width: 2; line-opacity: 1; }',
+    catchmentCSS: '{polygon-fill: rgba(164, 65, 178, 0.15); line-color: rgba(164, 65, 178, 1); line-width: 2; line-opacity: 1; }',
     catchmentCSS1ary: '{polygon-fill: #FE9A2E; polygon-opacity: 0.15; line-color: #FE9A2E; line-width: 2; line-opacity: 1; line-offset:2; }',
 
     // Specify a Maki icon name, hex color, and size (s, m, or l).

--- a/js/geo/MapControls.js
+++ b/js/geo/MapControls.js
@@ -9,7 +9,7 @@
     '  <div style="margin-bottom:5px"><b>Intake areas:</b></div>' +
     '  <span style="background: rgba(254, 154, 46, 0.25); border:solid; border-width: 2px; padding:1px; width:30px; border-color: #FE9A2E;">&nbsp;&nbsp;&nbsp;</span>' +
     '  <span style="padding:1px; width:100%;">Primary</span></p>' +
-    '  <span style="background: rgba(164, 65, 178, 0.15); border:solid; border-width: 2px; padding:1px; width:30px; border-color: #0B6138;">&nbsp;&nbsp;&nbsp;</span>' +
+    '  <span style="background: rgba(164, 65, 178, 0.15); border:solid; border-width: 2px; padding:1px; width:30px; border-color: rgba(164, 65, 178, 1);">&nbsp;&nbsp;&nbsp;</span>' +
     '  <span style="padding:1px; width:100%;">Secondary</span>' +
     '</div>';
     return legend;


### PR DESCRIPTION
Fixes #336 

* makes secondary catchment fill color match 2ndary icon (so both are violet)
* the catchment and key are the same color, one is just more transparent.

* Previously the catchment was green (#0B6138), now it's violet (rgba(164, 65, 178, 0.15);)
* Previously the key was green (rgba(11, 97, 56, 1); same green as above), now it too is violet

The change will make the map look as so:

![map view showing violet catchment](https://cloud.githubusercontent.com/assets/1072292/25829464/1c9ec44e-340b-11e7-9011-6eceed059de1.png)

Previously (currently, as of this writing) it looks like this:

![current map view, with greenish catchments](https://cloud.githubusercontent.com/assets/1072292/25829499/6472ff06-340b-11e7-85bb-8d44368859a7.png)
