### PR TITLE
updates Cartodb.js fixes disappearing intake areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,700' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
     <link rel="stylesheet" href="css/jquery-ui.min.css" />
     <link rel="stylesheet" href="css/jumbotron-narrow.css" />
     <link rel="stylesheet" href="css/style.css" />
@@ -361,7 +361,7 @@
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?client=gme-nswdepartmentofeducation1&libraries=places"></script>
     <script src="js/vendor/jquery-ui/jquery-ui.js"></script> <!-- for autocomplete -->
     <!-- script src="js/vendor/cartodb.js"></script-->
-    <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script src="js/vendor/handlebars-v3.0.0.js"></script>
     <script src="js/vendor/Leaflet.MakiMarkers.js"></script>
     <script src="js/config.js"></script>


### PR DESCRIPTION
Fixes #360 

This commit updates to the newer version of Carto which has been reported to not have the zoom / disappearing intake areas issue.

@richard-walsh or @reekypete would either of you be able to checkout the fixes/360-disappearing-intake-areas branch and confirm this fixes it for you? If so, we can go ahead and merge. 